### PR TITLE
Custom Message Type To Publish Image w.Detection Overlay and Match Struct

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -4,6 +4,7 @@
             "name": "Linux",
             "includePath": [
                 "${workspaceFolder}/**",
+                "${workspaceFolder}/install/**",
                 "/opt/ros/humble/**",
                 "/usr/include/opencv4"
             ],

--- a/src/rosbot/CMakeLists.txt
+++ b/src/rosbot/CMakeLists.txt
@@ -23,6 +23,8 @@ find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(geometry_msgs REQUIRED)
 
+find_package(rosbot_msgs REQUIRED)  # This is the custom message package
+
 # Include directories
 include_directories(
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -79,6 +81,7 @@ ament_target_dependencies(${EXECUTABLE_NAME_5}
   geometry_msgs
   sensor_msgs
   std_msgs
+  rosbot_msgs
 )
 
 # Install the executable into the package (so it can be called with ros2 run pkg ...)

--- a/src/rosbot/include/rosbot/detection.hpp
+++ b/src/rosbot/include/rosbot/detection.hpp
@@ -3,6 +3,8 @@
 #include <rclcpp/rclcpp.hpp>
 #include <geometry_msgs/msg/twist.hpp>
 #include <sensor_msgs/msg/image.hpp>
+#include <rosbot_msgs/msg/match.hpp>   // custom message type
+#include "rosbot_msgs/msg/detections.hpp" // custom message type
 
 #include <opencv2/opencv.hpp>
 #include <opencv2/highgui/highgui.hpp>
@@ -33,6 +35,8 @@ public:
 
 private:
   void _imageCallback(const sensor_msgs::msg::Image::SharedPtr msg);
+
+  rosbot_msgs::msg::Detections _convertToDetectionsMsg(std::shared_ptr<sensor_msgs::msg::Image> image, std::vector<Match> &matches);
 
   void _initDetection();
   std::vector<std::string> _loadClassList(const std::string &path);
@@ -78,6 +82,7 @@ private:
    */
   rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr _img_sub;
   rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr _detection_pub;
+  rclcpp::Publisher<rosbot_msgs::msg::Detections>::SharedPtr _detection_detailed_pub;
 
   /**
    * @brief Load the classes and the model for the detection application.

--- a/src/rosbot/include/rosbot/detection.hpp
+++ b/src/rosbot/include/rosbot/detection.hpp
@@ -12,7 +12,8 @@ class Detection : public rclcpp::Node
 {
 public:
   /**
-   * @brief Structure to hold the detection information from the YoloV5 model outputs.
+   * @brief Structure to hold the detection information from the YoloV5 model outputs. Made public for easy access from 
+   * other classes (though this is not essential as we use ROS2 topics to communicate detections between nodes).
    * 
    */
   struct Match
@@ -24,168 +25,78 @@ public:
   };
 
   /**
-   * @brief Construct a new Detection object
+   * @brief Construct a new Detection object for the ROS2 node. This node is responsible for detecting objects in images
+   * and publishing the results as image messages.
    * 
    */
   Detection();
 
 private:
-
-  /**
-   * @brief 
-   * 
-   * @tparam T 
-   * @param name 
-   * @param default_value 
-   */
-  template<typename T>
-  T init_parameter(const std::string& name, T default_value) {
-      declare_parameter(name, default_value);
-      T value = get_parameter(name).get_value<T>();
-      RCLCPP_INFO(get_logger(), "%s: %s", name.c_str(), to_string(value).c_str());
-      return value;
-  }
-  
-  /**
-   * @brief Template function to convert any type to string
-   * 
-   * @tparam T 
-   * @param value 
-   * @return std::string 
-   */
-  template<typename T>
-  std::string to_string(const T& value) {
-      return std::to_string(value);
-  }
-
-  /**
-   * @brief Overload for string type
-   * 
-   * @param value 
-   * @return std::string 
-   */
-  std::string to_string(const std::string& value) { return value; }
-
-  /**
-   * @brief Overload for bool type
-   * 
-   * @param value 
-   * @return std::string 
-   */
-  std::string to_string(const bool& value) { return value ? "true" : "false"; }
-
-  /**
-   * @brief 
-   * 
-   * @param msg 
-   */
   void _imageCallback(const sensor_msgs::msg::Image::SharedPtr msg);
 
-  /**
-   * @brief 
-   * 
-   * @param frame 
-   * @param obj 
-   */
-  void _initDetection(cv::Mat frame, cv::Rect obj);
-
-  /**
-   * @brief 
-   * 
-   * @param path 
-   * @return std::vector<std::string> 
-   */
+  void _initDetection();
   std::vector<std::string> _loadClassList(const std::string &path);
-
-  /**
-   * @brief 
-   * 
-   * @param net 
-   * @param is_cuda 
-   * @param path 
-   */
   void _loadNet(cv::dnn::Net &net, bool is_cuda, const std::string &path);
 
-  /**
-   * @brief 
-   * 
-   * @param source 
-   * @return cv::Mat 
-   */
-  cv::Mat _format_to_yolo(const cv::Mat &source);
-
-  /**
-   * @brief 
-   * 
-   * @param frame 
-   * @param output 
-   */
+  cv::Mat _formatToYolo(const cv::Mat &source);
   void _detect(cv::Mat &frame, std::vector<Match> &output);
-
-  /**
-   * @brief 
-   * 
-   * @param frame 
-   * @param match 
-   */
   void _drawBox(cv::Mat &frame, Match &match);
 
   /**
-   * @brief 
+   * @brief Helper function to initialise the parameters for the detection application. Template function to handle different types.
+   * 
+   * @tparam T is the type of the parameter.
+   * @param[in] name is the name of the parameter.
+   * @param[in] default_value is the default value of the parameter.
+   * @return T is the value of the parameter of type T.
+   */
+  template<typename T>
+  T _initParameter(const std::string& name, T default_value) {
+      declare_parameter(name, default_value);
+      T value = get_parameter(name).get_value<T>();
+      RCLCPP_INFO(get_logger(), "%s: %s", name.c_str(), _to_string(value).c_str());
+      return value;
+  }
+
+  /**
+   * @brief Helper function to convert different types to string.
+   * 
+   * @tparam T is the type of the value.
+   * @param[in] value is the value to convert to string.
+   * @return std::string is the string representation of the value.
+   */
+  template<typename T>
+  std::string _to_string(const T& value) {
+      return std::to_string(value);
+  }
+  std::string _to_string(const std::string& value) { return value; }
+  std::string _to_string(const bool& value) { return value ? "true" : "false"; }
+
+  /**
+   * @brief ROS2 subscriber and publisher for image messages.
    * 
    */
   rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr _img_sub;
-
-  /**
-   * @brief 
-   * 
-   */
   rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr _detection_pub;
 
   /**
-   * @brief 
+   * @brief Load the classes and the model for the detection application.
    * 
    */
   bool _is_detection_initialised;
-
-  /**
-   * @brief 
-   * 
-   */
   std::string _classes_path;
-
-  /**
-   * @brief 
-   * 
-   */
+  std::vector<std::string> _classes;
   std::string _model_path;
+  cv::dnn::Net _net;
 
   /**
-   * @brief 
+   * @brief Detection parameters.
    * 
    */
   bool _is_cuda;
-
   int _input_width;
-
   int _input_height;
-
   float _score_threshold;
-
   float _confidence_threshold;
-
   float _nms_threshold;
-
-  /**
-   * @brief 
-   * 
-   */
-  std::vector<std::string> _classes;
-
-  /**
-   * @brief Private
-   * 
-   */
-  cv::dnn::Net _net;
-
 };

--- a/src/rosbot/package.xml
+++ b/src/rosbot/package.xml
@@ -20,6 +20,7 @@
   <depend>nav_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
+  <depend>rosbot_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/src/rosbot_msgs/CMakeLists.txt
+++ b/src/rosbot_msgs/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.8)
+project(rosbot_msgs)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+
+# further dependencies manually.
+find_package(sensor_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+
+# Build custom message type for detection
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/Detections.msg"
+  DEPENDENCIES sensor_msgs
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # comment the line when a copyright and license is added to all source files
+  set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # comment the line when this package is in a git repo and when
+  # a copyright and license is added to all source files
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_export_dependencies(rosidl_default_runtime)
+ament_package()

--- a/src/rosbot_msgs/CMakeLists.txt
+++ b/src/rosbot_msgs/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(rosidl_default_generators REQUIRED)
 
 # Build custom message type for detection
 rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/Match.msg"
   "msg/Detections.msg"
   DEPENDENCIES sensor_msgs
 )

--- a/src/rosbot_msgs/LICENSE
+++ b/src/rosbot_msgs/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src/rosbot_msgs/msg/Detections.msg
+++ b/src/rosbot_msgs/msg/Detections.msg
@@ -1,7 +1,4 @@
 # File: rosbot/msg/Detections.msg
 
 sensor_msgs/Image image
-int32 class_id
-float32 confidence
-int32[4] box  # the box is defined by 4 integers (x, y, width, height)
-float32[4] color  # color is defined by 4 floats (RGBA)
+Match[] matches

--- a/src/rosbot_msgs/msg/Detections.msg
+++ b/src/rosbot_msgs/msg/Detections.msg
@@ -1,0 +1,7 @@
+# File: rosbot/msg/Detections.msg
+
+sensor_msgs/Image image
+int32 class_id
+float32 confidence
+int32[4] box  # the box is defined by 4 integers (x, y, width, height)
+float32[4] color  # color is defined by 4 floats (RGBA)

--- a/src/rosbot_msgs/msg/Match.msg
+++ b/src/rosbot_msgs/msg/Match.msg
@@ -1,0 +1,6 @@
+# File: rosbot_msgs/msg/Match.msg
+
+int32 class_id
+float32 confidence
+int32[4] box  # Assuming the box is defined by 4 integers (x, y, width, height)
+float32[4] color  # Assuming color is defined by 4 floats (RGBA)

--- a/src/rosbot_msgs/package.xml
+++ b/src/rosbot_msgs/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>rosbot_msgs</name>
+  <version>0.0.0</version>
+  <description>TODO: Package description</description>
+  <maintainer email="oheilmann5@gmail.com">parallels</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>sensor_msgs</depend>
+
+  <build_depend>rosidl_default_generators</build_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
When a detection is made using YoloV5 model, the overlayed image is published and viewable in RVIZ. This is good but it is likely that another node may wish to access the bounding box, class type etc. data.

I've added a custom msg package with Match and Detections message types to attach the corresponding matches in the frame. This is required as publishing separate image and match topics may not be out of sync (i.e. a subscriber may get image-1 and match-2 instead of intended image-1, match-1).

I don't like how I am publishing x2 of the same image (but one with the detections data) so will probs leave this PR open until I think of a better solution... (note: have to keep the image publisher so RVIZ can display)